### PR TITLE
Use public CircleCI context for build secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,22 +169,26 @@ workflows:
   build:
     jobs:
       - setup:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
       - watch:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - setup
           filters:
             tags:
               only: /.*/
       - test:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - setup
           filters:
             tags:
               only: /.*/
       - build_bins:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - setup
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,7 @@ workflows:
       #       tags:
       #         only: /.*/
       - publish_github:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build_bins
           filters:


### PR DESCRIPTION
* currently secrets are pulled from the project env variables in CircleCI
* using a shared context consolidates secrets storage, makes for easier secret updates
* majority of other repos already use the shared context, looks like this was set up
a while back before the context was created
* secret values are unchanged from what's currently in the project env variables