### PR TITLE
docker image with jq for CI/CD workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM stedolan/jq
+
+LABEL maintainer="Team Honeycomb <bees@honeycomb.io>"
+
+ADD bin/honeymarker /honeymarker
+
+ENTRYPOINT []
+CMD []


### PR DESCRIPTION
Defines a docker image based on the popular `jq` command line utility.  When paired with `jq` it's easy to add honeymarker to a CI/CD pipeline, where you can create deployment window markers instead of just point in time markers.

Here is a snippet with codefresh where this image can be used to create a marker and use the returned marker ID in a subsequent step to modify the marker with a new end time.

```
  before_deploy:
    title: Start deploy marker on Honeycomb
    stage: deploy
    image: puckpuck/honeymarker
    commands:
      - export HNY_MARKER_ID=$(/honeymarker -k ${{HNY_API_KEY}} -d ${{HNY_DATASET}} add -m "Deploy ${{CF_BUILD_ID}}" -t deploy -u "${{CF_BUILD_URL}}" | jq ".id")
      - cf_export HNY_MARKER_ID

  deploy:
    title: Deploy app
    stage: deploy
    ...

  after_deploy:
    title: End deploy marker on Honeycomb
    stage: deploy
    image: puckpuck/honeymarker
    commands:
      - env
      - /honeymarker -k ${{HNY_API_KEY}} -d ${{HNY_DATASET}} update -i ${{HNY_MARKER_ID}} -e $(date +%s)
```

in this example `jq` is used to extract the marker id from the marker create request.  This ID is preserved in a variable used within the codefresh pipeline workflow.


This would also require a release process to do the actual docker image release.