### PR TITLE
honeymarker: Add hidden flag to set Authorization header

### DIFF
--- a/add.go
+++ b/add.go
@@ -40,6 +40,9 @@ func (a *AddCommand) Execute(args []string) error {
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("X-Honeycomb-Team", options.WriteKey)
+	if options.AuthorizationHeader != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", options.AuthorizationHeader))
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/list.go
+++ b/list.go
@@ -60,6 +60,9 @@ func (l *ListCommand) Execute(args []string) error {
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Add("X-Honeycomb-Team", options.WriteKey)
 	req.Header.Add("X-Honeycomb-Dataset", options.Dataset)
+	if options.AuthorizationHeader != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", options.AuthorizationHeader))
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ type Options struct {
 	WriteKey string `short:"k" long:"writekey" description:"Honeycomb write key from https://ui.honeycomb.io/account" required:"true"`
 	Dataset  string `short:"d" long:"dataset" description:"Honeycomb dataset name from https://ui.honeycomb.io/dashboard" required:"true"`
 	APIHost  string `long:"api_host" hidden:"true" default:"https://api.honeycomb.io/"`
+
+	AuthorizationHeader string `long:"authorization-header" hidden:"true"`
 }
 
 var options Options

--- a/rm.go
+++ b/rm.go
@@ -22,6 +22,9 @@ func (r *RmCommand) Execute(args []string) error {
 	req, err := http.NewRequest("DELETE", postURL.String(), nil)
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Add("X-Honeycomb-Team", options.WriteKey)
+	if options.AuthorizationHeader != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", options.AuthorizationHeader))
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/update.go
+++ b/update.go
@@ -42,6 +42,9 @@ func (u *UpdateCommand) Execute(args []string) error {
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("X-Honeycomb-Team", options.WriteKey)
+	if options.AuthorizationHeader != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", options.AuthorizationHeader))
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
This change adds a new flag that allows specification of the Authorization header which is necessary for some deployments (especially in the context of Secure Tenancy).

There's a good amount of duplication in prepping these requests but I avoided a slightly bigger refactor here.

Refs #9 