### PR TITLE
chore(container): adjusted Dockerfile for public release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,22 @@
-FROM stedolan/jq
+FROM golang:1.16.5-alpine3.13 as builder
 
-LABEL maintainer="Team Honeycomb <solutions@honeycomb.io>"
+RUN apk update
 
-ADD bin/honeymarker /honeymarker
+WORKDIR /app
 
-ENTRYPOINT []
-CMD []
+ADD go.mod go.sum ./
+
+RUN go mod download
+RUN go mod verify
+
+ADD . .
+
+RUN CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64 \
+    go build \
+    -o honeymarker
+
+FROM scratch
+
+COPY --from=builder /app/honeymarker /usr/bin/honeymarker


### PR DESCRIPTION
Fixes #4 

Hej,
I just recognized that the Dockerfile is pretty outdated and based on the user request I created a simple Container definition which can be used for the use case.

```sh
docker run --rm honeymarker /usr/bin/honeymarker
  run 'honeymarker --help' for full usage details
the required flags `-d, --dataset' and `-k, --writekey' were not specified
```

Cheers!