### PR TITLE
Build and publish multi-arch docker images on tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,17 +177,12 @@ jobs:
           steps:
             - checkout
             - setup_remote_docker
+            - run: go install github.com/google/ko@latest
             - run:
-                name: Build Docker image
-                command: docker build -t $IMAGE_NAME:latest .
-            - run:
-                name: Publish Docker Image to Docker Hub
+                name: "Publish multi-arch docker image"
                 command: |
-                  echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-                  IMAGE_TAG=${CIRCLE_TAG/v/''}
-                  docker tag $IMAGE_NAME:latest $IMAGE_NAME:$IMAGE_TAG
-                  docker push $IMAGE_NAME:latest
-                  docker push $IMAGE_NAME:$IMAGE_TAG
+                  echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin;
+                  VERSION=${CIRCLE_TAG} KO_DOCKER_REPO=honeycombio build/build_docker.sh
 
 workflows:
   build:

--- a/build/build_docker.sh
+++ b/build/build_docker.sh
@@ -1,0 +1,20 @@
+set -o nounset
+set -o pipefail
+
+VERSION="${VERSION:-dev}"
+TAGS="latest"
+if [[ $VERSION != "dev" ]]; then
+    TAGS+=",$VERSION"
+fi
+
+unset GOOS
+unset GOARCH
+export KO_DOCKER_REPO=${KO_DOCKER_REPO:-ko.local}
+export GOFLAGS="-ldflags=-X=main.BuildID=$VERSION"
+export SOURCE_DATE_EPOCH=$(date +%s)
+# shellcheck disable=SC2086
+ko publish \
+  --tags "${TAGS}" \
+  --base-import-paths \
+  --platform "linux/amd64,linux/arm64" \
+  .


### PR DESCRIPTION
## Which problem is this PR solving?
When publishing to docker, our images should be built and be runnable on multiple architectures. This PR updates our docker image build process to use [Google KO](https://github.com/google/ko) to build the image.
- Resolves #24 

## Short description of the changes
- update CircleCI publish docker job to use ko to build multi-arch docker image
- add build/build_docker.sh to manage executing ko command