### PR TITLE
update installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```
-$ go get github.com/honeycombio/honeymarker
+$ go install github.com/honeycombio/honeymarker@latest
 $ honeymarker    # (if $GOPATH/bin is in your path.)
 ```
 


### PR DESCRIPTION
Recent versions of Go (1.17+ at least) prompt to move from `go get` to `go install`.

## Which problem is this PR solving?

- A minor fix to silence some warnings from recent Go versions

## Short description of the changes

- Docs update

