### PR TITLE
Switch away from Builder so that we get cacerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.16.5-alpine3.13 as builder
+FROM golang:1.16.5-alpine3.13
 
-RUN apk update
+RUN apk update && rm -rf /var/cache/apk/*
 
 WORKDIR /app
 
@@ -17,6 +17,4 @@ RUN CGO_ENABLED=0 \
     go build \
     -o honeymarker
 
-FROM scratch
-
-COPY --from=builder /app/honeymarker /usr/bin/honeymarker
+RUN mv /app/honeymarker /usr/bin/honeymarker


### PR DESCRIPTION
This allows `honeymarker` to terminate TLS when talking to `api.honeycomb.io`.

## Which problem is this PR solving?

- Fixes #28

## Short description of the changes

- Removes use of Docker Builder in favor a vanilla build that includes Alpine CA certs.

