### PR TITLE
ci: allow forked builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,6 @@ workflows:
   build:
     jobs:
       - setup:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
@@ -158,16 +157,16 @@ workflows:
             tags:
               only: /.*/
             branches:
-              ignore: /pull\/.*/
+              ignore:
+                - /pull\/.*/
+                - /dependabot\/.*/
       - test:
-          context: Honeycomb Secrets for Public Repos
           requires:
             - setup
           filters:
             tags:
               only: /.*/
       - build_bins:
-          context: Honeycomb Secrets for Public Repos
           requires:
             - setup
           filters:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #31 

## Short description of the changes

- only require secrets where necessary
- skip buildevents on dependabot builds as well
