### PR TITLE
Set `omitempty` on DateTime Marker Fields

### DIFF
--- a/marker.go
+++ b/marker.go
@@ -4,10 +4,10 @@ import "time"
 
 // The marker type, as described by https://honeycomb.io/docs/reference/api/#markers
 type marker struct {
-	ID string `json:"id"`
+	ID string `json:"id,omitempty"`
 
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// StartTime unix timestamp truncates to seconds
 	StartTime int64 `json:"start_time,omitempty"`


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves honeycombio/honeymarker#40 ("Creating Markers via Secure Tenancy (`1.10.1`) Contains Extraneous Fields").

## Short description of the changes

- Allows marker attributes `CreatedAt`, `UpdatedAt`, and `ID` to be omitted when they aren't explicitly [set on initialization](https://github.com/honeycombio/honeymarker/blob/main/add.go#L22).

