### PR TITLE
docs: how to use with environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ honeymarker    # (if $GOPATH/bin is in your path.)
 `$ honeymarker -k <your-writekey> -d <dataset> COMMAND [command-specific flags]`
 
 * `<your-writekey>` can be found on https://ui.honeycomb.io/account
-* `<dataset>` is the name of one of the datasets associated with the team whose writekey you're using.
+* `<dataset>` is the name of one of the datasets associated with the team whose writekey you're using. You can use `__all__` as dataset name to work with environment-wide markers.
 * `COMMAND` see below
 
 ## Available commands:

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ var UserAgent string
 
 type Options struct {
 	WriteKey string `short:"k" long:"writekey" description:"Honeycomb write key from https://ui.honeycomb.io/account" required:"true"`
-	Dataset  string `short:"d" long:"dataset" description:"Honeycomb dataset name from https://ui.honeycomb.io/dashboard" required:"true"`
+	Dataset  string `short:"d" long:"dataset" description:"Honeycomb dataset name from https://ui.honeycomb.io/dashboard (use __all__ for environment-wide markers)" required:"true"`
 	APIHost  string `long:"api_host" hidden:"true" default:"https://api.honeycomb.io/"`
 
 	AuthorizationHeader string `long:"authorization-header" hidden:"true"`


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- in order to create environment-wide markers a special dataset name (`__all__`) must be used

## Short description of the changes

- update readme and command flags

