### PR TITLE
maint: Rework and modernize builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - checkout
       - run: go test --timeout 10s -v ./...
 
-  build-bins:
+  build_bins:
     docker:
       - image: cimg/go:1.18
     parameters:
@@ -102,7 +102,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - aws-cli/install
-      - aws-cli/configure:
+      - aws-cli/setup:
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           aws-region: AWS_REGION
@@ -140,17 +140,11 @@ workflows:
   version: 2
   build:
     jobs:
-      - setup:
-          filters:
-            tags:
-              only: /.*/
       - test:
-          requires:
-            - setup
           filters:
             tags:
               only: /.*/
-      - build-bins:
+      - build_bins:
           <<: *platform_matrix
           requires:
             - test
@@ -163,7 +157,7 @@ workflows:
               arch: *arches
           context: Honeycomb Secrets for Public Repos
           requires:
-            - build-bins
+            - build_bins
           filters:
             tags:
               # temporarily allow tags that start with t so we can test builds without publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,12 @@ version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@2.0.3
   docker: circleci/docker@1.3.0
-  rpmbuild: aursu/rpmbuild@1.1.8
 
 executors:
   pkg:
     ## executor with fpm and npmbuild
     docker:
-      - image: alanfranz/fpm-within-docker:ubuntu-bionic
+      - image: alanfranz/fpm-within-docker:centos-8
 
 platform_matrix: &platform_matrix
   matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,13 @@ version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@2.0.3
   docker: circleci/docker@1.3.0
+  rpmbuild: aursu/rpmbuild@1.1.8
 
 executors:
   pkg:
-    ## executor with ruby for installing fpm and building packages
+    ## executor with fpm and npmbuild
     docker:
-      - image: cimg/ruby:3.1
+      - image: alanfranz/fpm-within-docker:ubuntu-bionic
 
 platform_matrix: &platform_matrix
   matrix:
@@ -73,7 +74,6 @@ jobs:
       - attach_workspace:
           at: ~/
       - checkout
-      - run: sudo gem install fpm
       - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t deb
       - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t rpm
       - run: echo "finished builds" && find ~/artifacts -ls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           GOARCH=<< parameters.arch >> \
           CGO_ENABLED=0 \
           go build -ldflags "-X main.BuildID=${CIRCLE_TAG}" \
-          -o $GOPATH/bin/honeymarker-<< parameters.os >>-<< parameters.arch >> \
+          -o ~/artifacts/honeymarker-<< parameters.os >>-<< parameters.arch >> \
           .
       - persist_to_workspace:
           root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
   pkg:
     ## executor with ruby for installing fpm and building packages
     docker:
-      - image: cimg/ruby:latest
+      - image: cimg/ruby:3.1
 
 platform_matrix: &platform_matrix
   matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - checkout
+      - run: sudo gem install fpm
       - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t deb && mv *.deb ~/artifacts
       - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t rpm && mv *.rpm ~/artifacts
       - run: echo "finished builds" && find ~/artifacts -ls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,8 @@ jobs:
           at: ~/
       - checkout
       - run: sudo gem install fpm
-      - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t deb && mv *.deb ~/artifacts
-      - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t rpm && mv *.rpm ~/artifacts
+      - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t deb
+      - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t rpm
       - run: echo "finished builds" && find ~/artifacts -ls
       - persist_to_workspace:
           root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,117 +1,114 @@
 version: 2.1
 
 orbs:
-  buildevents: honeycombio/buildevents@0.2.8
   aws-cli: circleci/aws-cli@2.0.3
+  docker: circleci/docker@1.3.0
 
 executors:
-  linuxgo:
-    docker:
-      - image: cimg/go:1.18
-        environment:
-          GO111MODULE: "on"
   pkg:
     ## executor with ruby for installing fpm and building packages
     docker:
       - image: cimg/ruby:latest
 
-commands:
-  go-build:
+platform_matrix: &platform_matrix
+  matrix:
+    parameters:
+      os: &oses ["linux", "darwin"] # <-- "windows" in the future!
+      arch: &arches ["amd64", "arm64", "arm", "386"]
+    exclude:
+      - os: darwin
+        arch: arm
+      - os: darwin
+        arch: "386"
+    # exclude: # And when Windows comes, we'll need to exclude the Win+arm64 combo:
+    #   - os: "windows"
+    #     arch: "arm64"
+
+jobs:
+  test:
+    docker:
+      - image: cimg/go:1.18
+    steps:
+      - checkout
+      - run: go test --timeout 10s -v ./...
+
+  build-bins:
+    docker:
+      - image: cimg/go:1.18
     parameters:
       os:
         description: Target operating system
         type: enum
-        enum: ["linux", "darwin"]
+        enum: *oses
         default: "linux"
       arch:
         description: Target architecture
         type: enum
-        enum: ["386", "amd64", "arm64"]
+        enum: *arches
         default: "amd64"
     steps:
+      - checkout
       - run: |
           GOOS=<< parameters.os >> \
           GOARCH=<< parameters.arch >> \
           CGO_ENABLED=0 \
-          buildevents cmd $CIRCLE_WORKFLOW_ID $BUILDEVENTS_SPAN_ID go_build -- \
           go build -ldflags "-X main.BuildID=${CIRCLE_TAG}" \
           -o $GOPATH/bin/honeymarker-<< parameters.os >>-<< parameters.arch >> \
-          ./...
-
-jobs:
-  setup:
-    executor: linuxgo
-    steps:
-      - buildevents/start_trace
-      - run: |
-          mkdir workspace
-          echo $(( $CIRCLE_BUILD_NUM + 1000 )) > workspace/build_id
-          cat workspace/build_id
+          .
       - persist_to_workspace:
-          root: workspace
+          root: ~/
           paths:
-            - build_id
-  watch:
-    executor: linuxgo
+            - artifacts
+
+  ## We only have to build packages for linux, so we iterate architectures and build rpm and deb for each.
+  build_packages:
+    executor: pkg
+    parameters:
+      arch:
+        description: Target architecture
+        type: enum
+        enum: *arches
+        default: "amd64"
     steps:
-      - buildevents/watch_build_and_finish
-
-  test:
-    executor: linuxgo
-    steps:
-      - buildevents/with_job_span:
-          steps:
-            - checkout
-            - buildevents/berun:
-                bename: go_test
-                becommand: go test -v ./...
-  build_bins:
-    executor: linuxgo
-    steps:
-      - buildevents/with_job_span:
-          steps:
-            - checkout
-            - go-build:
-                os: linux
-                arch: "386"
-            - go-build:
-                os: linux
-                arch: amd64
-            - go-build:
-                os: darwin
-                arch: amd64
-            - go-build:
-                os: linux
-                arch: arm64
-
-            - run: mkdir -v artifacts; cp -v $GOPATH/bin/honeymarker-* artifacts/
-
-            - run: echo "size=$(du -sb artifacts | cut -f 1)" >> $BASH_ENV
-            - buildevents/add_context:
-                field_name: artifacts_size_bytes
-                field_value: $size
-
-            - persist_to_workspace:
-                root: artifacts
-                paths:
-                  - honeymarker-*
-            - store_artifacts:
-                path: artifacts/
+      - attach_workspace:
+          at: ~/
+      - checkout
+      - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t deb && mv *.deb ~/artifacts
+      - run: ./build-pkg.sh -m << parameters.arch >> -v "${CIRCLE_TAG}" -t rpm && mv *.rpm ~/artifacts
+      - run: echo "finished builds" && find ~/artifacts -ls
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - artifacts
+      - store_artifacts:
+          path: ~/artifacts
 
   publish_github:
     docker:
-      - image: cibuilds/github:0.12.2
+      - image: cibuilds/github:0.13.0
     steps:
-      - buildevents/with_job_span:
-          steps:
-            - attach_workspace:
-                at: artifacts
-            - run:
-                name: "Publish Release on GitHub"
-                command: |
-                  echo "about to publish to tag ${CIRCLE_TAG}"
-                  ls -l *
-                  ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            echo "about to publish to tag ${CIRCLE_TAG}"
+            ls -l ~/artifacts/*
+            ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ~/artifacts
+
+  publish_s3:
+    executor: aws-cli/default
+    steps:
+      - attach_workspace:
+          at: ~/
+      - aws-cli/install
+      - aws-cli/configure:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-region: AWS_REGION
+      - run:
+          name: sync_s3_artifacts
+          command: aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/honeymarker/${CIRCLE_TAG}/
 
   build_docker:
     docker:
@@ -140,46 +137,58 @@ jobs:
             ./build-docker.sh
 
 workflows:
+  version: 2
   build:
     jobs:
       - setup:
           filters:
             tags:
               only: /.*/
-      - watch:
-          context: Honeycomb Secrets for Public Repos
-          requires:
-            - setup
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore:
-                - /pull\/.*/
-                - /dependabot\/.*/
       - test:
           requires:
             - setup
           filters:
             tags:
               only: /.*/
-      - build_bins:
+      - build-bins:
+          <<: *platform_matrix
           requires:
-            - setup
+            - test
           filters:
             tags:
               only: /.*/
+      - build_packages:
+          matrix:
+            parameters:
+              arch: *arches
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build-bins
+          filters:
+            tags:
+              # temporarily allow tags that start with t so we can test builds without publishing
+              only: /^[vt].*/
+            branches:
+              ignore: /.*/
       - build_docker:
           requires:
-            - setup
+            - test
           filters:
             tags:
               only: /.*/
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:
-            - build_bins
-            - build_docker
+            - build_packages
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - publish_s3:
+          context: Honeycomb Secrets for Public Repos
+          requires:
+            - build_packages
           filters:
             tags:
               only: /^v.*/

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -28,7 +28,7 @@ fi
 
 fpm -s dir -n honeymarker \
     -m "Honeycomb <solutions@honeycomb.io>" \
-    -p $GOPATH/bin \
+    -p ~/artifacts \
     -v $version \
     -t $pkg_type \
     -a $arch \

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -8,7 +8,7 @@ function usage() {
     exit 2
 }
 
-while getopts "v:t:" opt; do
+while getopts "v:t:m:" opt; do
     case "$opt" in
     v)
         version=$OPTARG
@@ -16,10 +16,13 @@ while getopts "v:t:" opt; do
     t)
         pkg_type=$OPTARG
         ;;
+    m)
+        arch=$OPTARG
+        ;;
     esac
 done
 
-if [ -z "$version" ] || [ -z "$pkg_type" ]; then
+if [ -z "$version" ] || [ -z "$pkg_type" ] || [ -z "$arch" ]; then
     usage
 fi
 
@@ -28,4 +31,5 @@ fpm -s dir -n honeymarker \
     -p $GOPATH/bin \
     -v $version \
     -t $pkg_type \
-    artifacts/honeymarker=/usr/bin/honeymarker
+    -a $arch \
+    artifacts/honeymarker-linux-${arch}=/usr/bin/honeymarker

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -32,4 +32,4 @@ fpm -s dir -n honeymarker \
     -v $version \
     -t $pkg_type \
     -a $arch \
-    artifacts/honeymarker-linux-${arch}=/usr/bin/honeymarker
+    ~/artifacts/honeymarker-linux-${arch}=/usr/bin/honeymarker


### PR DESCRIPTION
## Which problem is this PR solving?

Turns out that we need to be able to upload builds to S3 as well as github, because we have links to the builds that people build into build scripts. This restores that capability and modernizes it. 

## Short description of the changes

- Clean up the CircleCI config and the shell script that builds packages. 

This PR will be followed up with further doc work to explain how to access the images.

