### PR TITLE
strip the leading v from debian versions

### DIFF
--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -26,6 +26,11 @@ if [ -z "$version" ] || [ -z "$pkg_type" ] || [ -z "$arch" ]; then
     usage
 fi
 
+if [ "$pkg_type" -eq "deb" ]; then
+    # for .deb, remove the leading v from version since debian doesn't permit that
+    version=${OPTARG:1}
+fi
+
 PACKAGE_DIR=~/packages/${arch}
 mkdir -p ${PACKAGE_DIR}
 fpm -s dir -n honeymarker \


### PR DESCRIPTION
## Which problem is this PR solving?

- Debian doesn't permit a leading v on version numbers; this removes it during the packaging step for .deb only. Fixes #53.

## Short description of the changes

- Use bash substring to strip the first character from the version if the package type is `deb`.

