### PR TITLE
Change --version to version subcommand

### DIFF
--- a/add.go
+++ b/add.go
@@ -19,6 +19,7 @@ type AddCommand struct {
 }
 
 func (a *AddCommand) Execute(args []string) error {
+	checkRequiredFlags()
 	blob, err := json.Marshal(marker{
 		StartTime: a.StartTime,
 		EndTime:   a.EndTime,

--- a/list.go
+++ b/list.go
@@ -50,6 +50,7 @@ func (l *ListCommand) formatTime(timestamp int64) string {
 }
 
 func (l *ListCommand) Execute(args []string) error {
+	checkRequiredFlags()
 	postURL, err := url.Parse(options.APIHost)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to parse URL %s", options.APIHost)

--- a/rm.go
+++ b/rm.go
@@ -13,6 +13,7 @@ type RmCommand struct {
 }
 
 func (r *RmCommand) Execute(args []string) error {
+	checkRequiredFlags()
 	postURL, err := url.Parse(options.APIHost)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to parse URL %s", options.APIHost)

--- a/update.go
+++ b/update.go
@@ -20,6 +20,7 @@ type UpdateCommand struct {
 }
 
 func (u *UpdateCommand) Execute(args []string) error {
+	checkRequiredFlags()
 	blob, err := json.Marshal(marker{
 		StartTime: u.StartTime,
 		EndTime:   u.EndTime,

--- a/version.go
+++ b/version.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+type VersionCommand struct {
+}
+
+// Prints the version number and exits
+func (v *VersionCommand) Execute(args []string) error {
+	fmt.Println(BuildID)
+	os.Exit(0)
+	return nil
+}


### PR DESCRIPTION
## Which problem is this PR solving?

In #54, I attempted to add a `--version` flag, but because of the command-based architecture of the system it's literally impossible to do it without rewriting the whole tool, so I had to move things to a version subcommand. 

Fixes #58.

## Short description of the changes

- Create version subcommand
- Move evaluation of required flags into a subroutine and call it almost everywhere

