### PR TITLE
Fix link to markers docs in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/honeymarker?color=success)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
 
-`honeymarker` provides a simple CRUD interface for dealing with per-dataset [https://honeycomb.io/docs/guides/best-practices/#use-markers](markers) on https://honeycomb.io/.
+`honeymarker` provides a simple CRUD interface for dealing with per-dataset [markers](https://docs.honeycomb.io/working-with-your-data/markers/) on https://honeycomb.io/.
 
 ## Installation
 


### PR DESCRIPTION
The markdown was the wrong way round (`[target](label)` instead of `[label](target)`) and the URL now 404s. Swap it round and replace it with a working URL.