### PR TITLE
[ci] send Github issues and PRs to Asana

### DIFF
--- a/.github/workflows/gh-issue-to-asana.yml
+++ b/.github/workflows/gh-issue-to-asana.yml
@@ -1,0 +1,19 @@
+name: Sync Github Issue to Asana
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  create-asana-task:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create Asana task
+        uses: honeycombio/gha-create-asana-task@v1.0.0
+        with:
+          asana-secret: ${{ secrets.ASANA_PAT }}
+          asana-workspace-id: ${{ secrets.ASANA_WORKSPACE_ID }}
+          asana-project-id: ${{ secrets.ASANA_PROJECT_ID }}
+          asana-section-id: ${{ secrets.ASANA_SECTION_ID }}
+          asana-task-name: ${{ github.event.issue.title }}
+          asana-task-description: ${{ github.event.issue.body }}

--- a/.github/workflows/gh-pr-to-asana.yml
+++ b/.github/workflows/gh-pr-to-asana.yml
@@ -1,0 +1,25 @@
+name: Sync Github Pull Request to Asana
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  create-asana-attachment-job:
+    runs-on: ubuntu-latest
+    name: Create pull request attachments on Asana tasks
+    steps:
+      - name: Create pull request attachments
+        uses: Asana/create-app-attachment-github-action@latest
+        id: postAttachment
+        with:
+          asana-secret: ${{ secrets.ASANA_SECRET }}
+      - name: Create task if not found
+        if: ${{ !contains(steps.postAttachment.outputs.status, '201') }}
+        uses: honeycombio/gha-create-asana-task@v1.0.0
+        with:
+          asana-secret: ${{ secrets.ASANA_PAT }}
+          asana-workspace-id: ${{ secrets.ASANA_WORKSPACE_ID }}
+          asana-project-id: ${{ secrets.ASANA_PROJECT_ID }}
+          asana-section-id: ${{ secrets.ASANA_SECTION_ID }}
+          asana-task-name: ${{ github.event.pull_request.title }}
+          asana-task-description: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
## Which problem is this PR solving?

https://app.asana.com/0/1198607545155957/1203451723732961/f

## Short description of the changes

This adds 2 Github Actions to the repo to run on issue creation and PR opens/reopens. All issues become tasks and PRs become tasks if they don't have an Asana link in the description. These tasks go to our team board in the Inbox column.

