### PR TITLE
ci: add permissions

### DIFF
--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -4,6 +4,8 @@ jobs:
   apply-labels:
     runs-on: ubuntu-latest
     name: Apply common project labels
+    permissions:
+      pull-requests: write
     steps:
       - uses: honeycombio/oss-management-actions/labels@v1
         with:


### PR DESCRIPTION
## Which problem is this PR solving?

Workflows that require write permissions need to declare them, otherwise they will fail in repositories with more conservative default permissions (`read`)

## Short description of the changes

- specify `pull-requests: write`