### PR TITLE
Adding env to write key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,14 +27,14 @@ platform_matrix: &platform_matrix
 jobs:
   test:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.21
     steps:
       - checkout
       - run: go test --timeout 10s -v ./...
 
   build_bins:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.21
     parameters:
       os:
         description: Target operating system
@@ -87,7 +87,7 @@ jobs:
 
   consolidate_artifacts:
     docker:
-    - image: cimg/go:1.18
+    - image: cimg/go:1.21
     steps:
       - attach_workspace:
           at: ~/
@@ -128,7 +128,7 @@ jobs:
 
   build_docker:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.21
     steps:
       - run: go install github.com/google/ko@latest
       - checkout
@@ -139,7 +139,7 @@ jobs:
 
   publish_docker:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.21
     steps:
       - run: go install github.com/google/ko@latest
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.1-alpine3.15 as builder
+FROM golang:1.21.3-alpine3.18 as builder
 
 RUN apk update
 
@@ -20,3 +20,4 @@ RUN CGO_ENABLED=0 \
 FROM scratch
 
 COPY --from=builder /app/honeymarker /usr/bin/honeymarker
+ENTRYPOINT [ "/usr/bin/honeymarker" ]

--- a/add.go
+++ b/add.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -37,7 +37,7 @@ func (a *AddCommand) Execute(args []string) error {
 		return errors.New(errMsg)
 	}
 	postURL.Path = "/1/markers/" + options.Dataset
-	req, err := http.NewRequest("POST", postURL.String(), bytes.NewBuffer(blob))
+	req, _ := http.NewRequest("POST", postURL.String(), bytes.NewBuffer(blob))
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("X-Honeycomb-Team", options.WriteKey)
@@ -49,7 +49,7 @@ func (a *AddCommand) Execute(args []string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.18
 
 require github.com/jessevdk/go-flags v1.5.0
 
-require golang.org/x/sys v0.1.0 // indirect
+require golang.org/x/sys v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/list.go
+++ b/list.go
@@ -57,7 +57,7 @@ func (l *ListCommand) Execute(args []string) error {
 		return errors.New(errMsg)
 	}
 	postURL.Path = "/1/markers/" + options.Dataset
-	req, err := http.NewRequest("GET", postURL.String(), nil)
+	req, _ := http.NewRequest("GET", postURL.String(), nil)
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Add("X-Honeycomb-Team", options.WriteKey)
 	req.Header.Add("X-Honeycomb-Dataset", options.Dataset)

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ var BuildID string = "dev"
 var UserAgent string
 
 type Options struct {
-	WriteKey string `short:"k" long:"writekey" description:"Honeycomb write key from https://ui.honeycomb.io/account"`
+	WriteKey string `short:"k" long:"writekey" env:"HONEYCOMB_API_KEY" description:"Honeycomb write key from https://ui.honeycomb.io/account"`
 	Dataset  string `short:"d" long:"dataset" description:"Honeycomb dataset name from https://ui.honeycomb.io/dashboard (use __all__ for environment-wide markers)"`
 	APIHost  string `long:"api_host" hidden:"true" default:"https://api.honeycomb.io/"`
 

--- a/rm.go
+++ b/rm.go
@@ -3,7 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -20,7 +20,7 @@ func (r *RmCommand) Execute(args []string) error {
 		return errors.New(errMsg)
 	}
 	postURL.Path = "/1/markers/" + options.Dataset + "/" + r.MarkerID
-	req, err := http.NewRequest("DELETE", postURL.String(), nil)
+	req, _ := http.NewRequest("DELETE", postURL.String(), nil)
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Add("X-Honeycomb-Team", options.WriteKey)
 	if options.AuthorizationHeader != "" {
@@ -31,7 +31,7 @@ func (r *RmCommand) Execute(args []string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/update.go
+++ b/update.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -39,7 +39,7 @@ func (u *UpdateCommand) Execute(args []string) error {
 	}
 	postURL.Path = "/1/markers/" + options.Dataset + "/" + u.MarkerID
 
-	req, err := http.NewRequest("PUT", postURL.String(), bytes.NewBuffer(blob))
+	req, _ := http.NewRequest("PUT", postURL.String(), bytes.NewBuffer(blob))
 	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("X-Honeycomb-Team", options.WriteKey)
@@ -51,7 +51,7 @@ func (u *UpdateCommand) Execute(args []string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- #75 

## Short description of the changes

- Pulling `--writekey` option from the `HONEYCOMB_API_KEY` environment variable as a default if `-k/--writekey` is not provided
- Updating Go dependency tree and build versions (Go 1.21, Alpine 3.18, `go get -u ./...`, `go mod tidy`)

