### PR TITLE
fix: strip leading 'v' from version for Debian

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -o nounset
 set -o pipefail
 set -o xtrace
@@ -15,6 +17,7 @@ unset GOOS
 unset GOARCH
 export KO_DOCKER_REPO=${KO_DOCKER_REPO:-ko.local}
 export GOFLAGS="-ldflags=-X=main.BuildID=$VERSION"
+# shellcheck disable=SC2155
 export SOURCE_DATE_EPOCH=$(date +%s)
 # shellcheck disable=SC2086
 ko publish \

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -1,14 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Build deb or rpm packages for honeymarker.
-set -e
+set -ex
 
 function usage() {
-    echo "Usage: build-pkg.sh -v <version> -t <package_type>"
+    echo "Usage: build-pkg.sh -v <version> -t <package_type> -m <arch>"
     exit 2
 }
 
 while getopts "v:t:m:" opt; do
+    # shellcheck disable=SC2220
     case "$opt" in
     v)
         version=$OPTARG
@@ -26,17 +27,17 @@ if [ -z "$version" ] || [ -z "$pkg_type" ] || [ -z "$arch" ]; then
     usage
 fi
 
-if [ "$pkg_type" -eq "deb" ]; then
+if [ "$pkg_type" == "deb" ]; then
     # for .deb, remove the leading v from version since debian doesn't permit that
-    version=${version:1}
+    version=${version#"v"}
 fi
 
 PACKAGE_DIR=~/packages/${arch}
-mkdir -p ${PACKAGE_DIR}
+mkdir -p "${PACKAGE_DIR}"
 fpm -s dir -n honeymarker \
     -m "Honeycomb <solutions@honeycomb.io>" \
-    -p ${PACKAGE_DIR} \
-    -v $version \
-    -t $pkg_type \
-    -a $arch \
-    ~/binaries/honeymarker-linux-${arch}=/usr/bin/honeymarker
+    -p "${PACKAGE_DIR}" \
+    -v "$version" \
+    -t "$pkg_type" \
+    -a "$arch" \
+    ~/binaries/"honeymarker-linux-${arch}=/usr/bin/honeymarker"

--- a/pkg-test/Dockerfile.deb
+++ b/pkg-test/Dockerfile.deb
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:22.04
 ARG package
 COPY $package .
 

--- a/pkg-test/Dockerfile.rpm
+++ b/pkg-test/Dockerfile.rpm
@@ -1,4 +1,4 @@
-FROM centos:6
+FROM rockylinux/rockylinux:8-minimal
 
 ARG package
 COPY $package .

--- a/pkg-test/test.sh
+++ b/pkg-test/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Smoke-test package installation by installing packages into a container. This
 # assumes that packages exist in $GOPATH/bin
@@ -10,10 +10,10 @@ if [ "$#" -ne 1 ]; then echo "usage: test.sh <build id>"; exit 1; fi
 BUILDID=$1
 DEB=honeymarker_${BUILDID}_amd64.deb
 RPM=honeymarker-${BUILDID}-1.x86_64.rpm
-DIR=`dirname $0`
-echo docker build --build-arg package=$DEB -f Dockerfile.deb $DIR
+DIR=$(dirname "$0")
+echo docker build --build-arg package="$DEB" -f Dockerfile.deb "$DIR"
 
-cp $GOPATH/bin/$DEB $DIR
-cp $GOPATH/bin/$RPM $DIR
-docker build --build-arg package=$DEB -f $DIR/Dockerfile.deb $DIR
-docker build --build-arg package=$RPM -f $DIR/Dockerfile.rpm $DIR
+cp "$GOPATH/bin/$DEB" "$DIR"
+cp "$GOPATH/bin/$RPM" "$DIR"
+docker build --build-arg package="$DEB" -f "$DIR/Dockerfile.deb" "$DIR"
+docker build --build-arg package="$RPM" -f "$DIR/Dockerfile.rpm" "$DIR"


### PR DESCRIPTION
Strips the leading 'v' from the version for Debian packaging, as well as a little housekeeping on the shell scripts.

#55 was the first pass at fixing this but was using a numerical comparison and was failing silently with:

> ./build-pkg.sh: line 29: [: deb: integer expression expected

## Which problem is this PR solving?

- Closes #64 


