### PR TITLE
Document use of configuration key instead of writekey

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ $ honeymarker    # (if $GOPATH/bin is in your path.)
 
 ## Usage
 
-`$ honeymarker -k <your-writekey> -d <dataset> [--version] COMMAND [command-specific flags]`
+`$ honeymarker -k <your-configuration-key> -d <dataset> [--version] COMMAND [command-specific flags]`
 
-* `<your-writekey>` can be found on https://ui.honeycomb.io/account
-* `<dataset>` is the name of one of the datasets associated with the team whose writekey you're using. You can use `__all__` as dataset name to work with environment-wide markers.
+* `<your-configuration-key>` can be found on `https://ui.honeycomb.io/<team>/environments/<environment>/api_keys`. You can also set it as `HONEYCOMB_API_KEY` 
+* `<dataset>` is the name of one of the datasets associated with the team whose configuration key you're using. You can use `__all__` as dataset name to work with environment-wide markers.
 * `COMMAND` see below
 
 ## Available commands:
@@ -55,7 +55,7 @@ as a link in the UI, and clicking it will take you to the URL.
 Example:
 
 ```
-$ ./honeymarker -k $WRITE_KEY -d myservice add -t deploy -m "build 192837"
+$ ./honeymarker -k $CONFIGURATION_KEY -d myservice add -t deploy -m "build 192837"
 {"created_at":"2017-06-28T18:55:11Z","updated_at":"2017-06-28T18:55:11Z","start_time":1498676111,"message":"build 192837","type":"deploy","id":"n71R3zM1Tn3"}
 
 $
@@ -70,7 +70,7 @@ $
 
 Example:
 ```
-$ ./honeymarker -k $WRITE_KEY -d myservice list
+$ ./honeymarker -k $CONFIGURATION_KEY -d myservice list
 | ID          |      Start Time |        End Time | Type         | Message      | URL |
 +-------------+-----------------+-----------------+--------------+--------------+-----+
 | n71R3zM1Tn3 | Jun 28 11:55:11 |                 | deploy       | build 192837 |     |
@@ -93,7 +93,7 @@ The marker ID is available from the `list` command, and is also output to the co
 
 Example:
 ```
-$ ./honeymarker -k $WRITE_KEY -d myservice update -i n71R3zM1Tn3 -u "http://my.service.co/builds/192837"
+$ ./honeymarker -k $CONFIGURATION_KEY -d myservice update -i n71R3zM1Tn3 -u "http://my.service.co/builds/192837"
 {"created_at":"2017-06-28T18:55:11Z","updated_at":"2017-06-28T18:55:11Z","start_time":1498676111,"message":"build 192837","type":"deploy","url":"http://my.service.co/builds/192837","id":"n71R3zM1Tn3"}
 
 $
@@ -109,10 +109,10 @@ The marker ID is available from the `list` command, and is also output to the co
 
 Example:
 ```
-$ ./honeymarker -k $WRITE_KEY -d myservice rm -i n71R3zM1Tn3
+$ ./honeymarker -k $CONFIGURATION_KEY -d myservice rm -i n71R3zM1Tn3
 {"created_at":"2017-06-28T18:55:11Z","updated_at":"2017-06-28T18:57:47Z","start_time":1498676111,"message":"build 192837","type":"deploy","url":"http://my.service.co/builds/192837","id":"n71R3zM1Tn3"}
 
-$ ./honeymarker -k $WRITE_KEY -d myservice list
+$ ./honeymarker -k $CONFIGURATION_KEY -d myservice list
 | ID          |      Start Time |        End Time | Type         | Message | URL |
 +-------------+-----------------+-----------------+--------------+---------+-----+
 $

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ var BuildID string = "dev"
 var UserAgent string
 
 type Options struct {
-	WriteKey string `short:"k" long:"writekey" env:"HONEYCOMB_API_KEY" description:"Honeycomb write key from https://ui.honeycomb.io/account"`
+	WriteKey string `short:"k" long:"writekey" env:"HONEYCOMB_API_KEY" description:"Honeycomb configuration key from https://ui.honeycomb.io/<team>/environments/<environment>/api_keys"`
 	Dataset  string `short:"d" long:"dataset" description:"Honeycomb dataset name from https://ui.honeycomb.io/dashboard (use __all__ for environment-wide markers)"`
 	APIHost  string `long:"api_host" hidden:"true" default:"https://api.honeycomb.io/"`
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- I was trying to setup Honeymarker and spent a bunch of time trying to figure out which key to use. The link provided no longer took you to a relevant page, and the name "Writekey" doesn't seem to be used in the Honeycomb UI anymore. I initially assumed that Writekey was closest to Ingest key and tried that but it didn't work. Then I tried a configuration key and that worked.

## Short description of the changes

- Renames writekey to configuration key in the docs and CLI help. Doesn't refactor the whole app to use it though.

