### PR TITLE
fix(list): include the year for times when in a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ $
 Example:
 ```
 $ ./honeymarker -k $CONFIGURATION_KEY -d myservice list
-| ID          |         Start Time |           End Time | Type         | Message      | URL |
-+-------------+--------------------+--------------------+--------------+--------------+-----+
-| n71R3zM1Tn3 | Jun 28 24 11:55:11 |                    | deploy       | build 192837 |     |
+| ID          |           Start Time |             End Time | Type         | Message      | URL |
++-------------+----------------------+----------------------+--------------+--------------+-----+
+| n71R3zM1Tn3 | Jun 28 2024 11:55:11 |                      | deploy       | build 192837 |     |
 
 $
 ```
@@ -113,8 +113,8 @@ $ ./honeymarker -k $CONFIGURATION_KEY -d myservice rm -i n71R3zM1Tn3
 {"created_at":"2017-06-28T18:55:11Z","updated_at":"2017-06-28T18:57:47Z","start_time":1498676111,"message":"build 192837","type":"deploy","url":"http://my.service.co/builds/192837","id":"n71R3zM1Tn3"}
 
 $ ./honeymarker -k $CONFIGURATION_KEY -d myservice list
-| ID          |         Start Time |           End Time | Type         | Message | URL |
-+-------------+--------------------+--------------------+--------------+---------+-----+
+| ID          |           Start Time |             End Time | Type         | Message | URL |
++-------------+----------------------+----------------------+--------------+---------+-----+
 $
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ honeymarker    # (if $GOPATH/bin is in your path.)
 
 `$ honeymarker -k <your-configuration-key> -d <dataset> [--version] COMMAND [command-specific flags]`
 
-* `<your-configuration-key>` can be found on `https://ui.honeycomb.io/<team>/environments/<environment>/api_keys`. You can also set it as `HONEYCOMB_API_KEY` 
+* `<your-configuration-key>` can be found on `https://ui.honeycomb.io/<team>/environments/<environment>/api_keys`. You can also set it as `HONEYCOMB_API_KEY`
 * `<dataset>` is the name of one of the datasets associated with the team whose configuration key you're using. You can use `__all__` as dataset name to work with environment-wide markers.
 * `COMMAND` see below
 
@@ -71,9 +71,9 @@ $
 Example:
 ```
 $ ./honeymarker -k $CONFIGURATION_KEY -d myservice list
-| ID          |      Start Time |        End Time | Type         | Message      | URL |
-+-------------+-----------------+-----------------+--------------+--------------+-----+
-| n71R3zM1Tn3 | Jun 28 11:55:11 |                 | deploy       | build 192837 |     |
+| ID          |         Start Time |           End Time | Type         | Message      | URL |
++-------------+--------------------+--------------------+--------------+--------------+-----+
+| n71R3zM1Tn3 | Jun 28 24 11:55:11 |                    | deploy       | build 192837 |     |
 
 $
 ```
@@ -113,8 +113,8 @@ $ ./honeymarker -k $CONFIGURATION_KEY -d myservice rm -i n71R3zM1Tn3
 {"created_at":"2017-06-28T18:55:11Z","updated_at":"2017-06-28T18:57:47Z","start_time":1498676111,"message":"build 192837","type":"deploy","url":"http://my.service.co/builds/192837","id":"n71R3zM1Tn3"}
 
 $ ./honeymarker -k $CONFIGURATION_KEY -d myservice list
-| ID          |      Start Time |        End Time | Type         | Message | URL |
-+-------------+-----------------+-----------------+--------------+---------+-----+
+| ID          |         Start Time |           End Time | Type         | Message | URL |
++-------------+--------------------+--------------------+--------------+---------+-----+
 $
 ```
 

--- a/list.go
+++ b/list.go
@@ -19,7 +19,7 @@ type ListCommand struct {
 
 const (
 	IdColumnWidth         = 11
-	TimeColumnWidthPretty = 18
+	TimeColumnWidthPretty = 20
 	TimeColumnWidthUnix   = 10
 	TypeColumnWidth       = 12
 
@@ -29,7 +29,7 @@ const (
 	URLColumnMinWidth     = len("URL")
 
 	// TimeFormat is the same as time.Stamp but with the year added to it.
-	TimeFormat = "Jan _2 06 15:04:05"
+	TimeFormat = "Jan _2 2006 15:04:05"
 )
 
 func truncateStr(str string, maxWidth int) string {

--- a/list.go
+++ b/list.go
@@ -19,7 +19,7 @@ type ListCommand struct {
 
 const (
 	IdColumnWidth         = 11
-	TimeColumnWidthPretty = 15
+	TimeColumnWidthPretty = 18
 	TimeColumnWidthUnix   = 10
 	TypeColumnWidth       = 12
 
@@ -27,6 +27,9 @@ const (
 	MessageColumnMinWidth = len("Message")
 	URLColumnMaxWidth     = 30
 	URLColumnMinWidth     = len("URL")
+
+	// TimeFormat is the same as time.Stamp but with the year added to it.
+	TimeFormat = "Jan _2 06 15:04:05"
 )
 
 func truncateStr(str string, maxWidth int) string {
@@ -46,7 +49,7 @@ func (l *ListCommand) formatTime(timestamp int64) string {
 	}
 
 	t := time.Unix(timestamp, 0)
-	return t.Format(time.Stamp)
+	return t.Format(TimeFormat)
 }
 
 func (l *ListCommand) Execute(args []string) error {


### PR DESCRIPTION
## Which problem is this PR solving?

The current `list` command doesn't include the year for any timestamps, so there's a bit of a lack in clarity when looking at markers that span multiple years.

![image](https://github.com/user-attachments/assets/b65593cd-3b72-48c6-bc67-bc4cdecebb98)


## Short description of the changes

This change keeps the time format the same but just adds the year to it.

![image](https://github.com/user-attachments/assets/ffd1e3b3-2f7b-4898-86fb-790b68954b82)
